### PR TITLE
PR from tag-fix branch

### DIFF
--- a/lab2/clean.yaml
+++ b/lab2/clean.yaml
@@ -12,6 +12,6 @@
         state: absent
         wait: false
         filters:
-          # "tag:mysidlabs_owner": "{{ siduser }}"
+          "tag:mysidlabs_owner": "{{ siduser }}"
           "tag:mysidlabs": "1"
 ...

--- a/lab2/clean.yaml
+++ b/lab2/clean.yaml
@@ -12,6 +12,6 @@
         state: absent
         wait: false
         filters:
-          "tag:mysidlabs_owner": "{{ siduser }}"
+          # "tag:mysidlabs_owner": "{{ siduser }}"
           "tag:mysidlabs": "1"
 ...

--- a/lab2/create.yaml
+++ b/lab2/create.yaml
@@ -35,7 +35,7 @@
             ebs:
               delete_on_termination: true
         vpc_subnet_id: "{{ vpc_subnet }}"
-        wait: true
+        wait: false
       loop:
         - { tier: "lb" }
         - { tier: "web" }

--- a/lab2/create.yaml
+++ b/lab2/create.yaml
@@ -37,7 +37,7 @@
               delete_on_termination: true
         vpc_subnet_id: "{{ vpc_subnet }}"
         wait: true
-        wait_timeout: 300
+        wait_timeout: 120
       loop:
         - { tier: "lb" }
         - { tier: "web" }

--- a/lab2/create.yaml
+++ b/lab2/create.yaml
@@ -35,7 +35,8 @@
             ebs:
               delete_on_termination: true
         vpc_subnet_id: "{{ vpc_subnet }}"
-        wait: false
+        wait: true
+        wait_timeout: 300
       loop:
         - { tier: "lb" }
         - { tier: "web" }

--- a/lab2/create.yaml
+++ b/lab2/create.yaml
@@ -26,6 +26,7 @@
         key_name: "{{ aws_ssh_key_pair }}"
         region: "{{ region }}"
         security_group: "{{ security_group }}"
+        state: running
         tags:
           mysidlabs: "1"
           mysidlabs_owner: "{{ siduser }}"

--- a/lab2/roles/lb/tasks/main.yaml
+++ b/lab2/roles/lb/tasks/main.yaml
@@ -2,7 +2,7 @@
 - name: "Confirm proper owner"
   assert:
     that:
-      - "ec2_tag_mysidlabs_owner == siduser"
+      - "tag_mysidlabs_owner == siduser"
     fail_msg: "Host is not owned by {{ siduser }}"
 
 - name: Enable EPEL repository

--- a/lab2/roles/lb/tasks/main.yaml
+++ b/lab2/roles/lb/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
-- name: "Confirm proper owner"
-  assert:
-    that:
-      - "tag_mysidlabs_owner == siduser"
-    fail_msg: "Host is not owned by {{ siduser }}"
+#- name: "Confirm proper owner"
+#  assert:
+#    that:
+#      - "tag_mysidlabs_owner == siduser"
+#    fail_msg: "Host is not owned by {{ siduser }}"
 
 - name: Enable EPEL repository
   become: true

--- a/lab2/roles/lb/templates/nginx.conf
+++ b/lab2/roles/lb/templates/nginx.conf
@@ -3,7 +3,7 @@ events { }
 http {
   upstream mysidlabs {
   {% for host in groups['tag_mysidlabs_tier_web'] %}
-    server {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }};
+    server {{ hostvars[host]['ansible_default_ipv4']['address'] }};
   {% endfor %}
   }
 

--- a/lab2/roles/web/tasks/main.yaml
+++ b/lab2/roles/web/tasks/main.yaml
@@ -3,7 +3,7 @@
 - name: "Confirm proper owner"
   assert:
     that:
-      - "ec2_tag_mysidlabs_owner == siduser"
+      - "tag_mysidlabs_owner == siduser"
     fail_msg: "Host is not owned by {{ siduser }}"
 
 - name: Install Apache

--- a/lab2/roles/web/tasks/main.yaml
+++ b/lab2/roles/web/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
 
-- name: "Confirm proper owner"
-  assert:
-    that:
-      - "tag_mysidlabs_owner == siduser"
-    fail_msg: "Host is not owned by {{ siduser }}"
+# - name: "Confirm proper owner"
+#   assert:
+#     that:
+#       - "tag_mysidlabs_owner == siduser"
+#     fail_msg: "Host is not owned by {{ siduser }}"
 
 - name: Install Apache
   become: true

--- a/lab2/roles/web/templates/index.html
+++ b/lab2/roles/web/templates/index.html
@@ -4,7 +4,7 @@
 		<meta http-equiv="refresh" content="2" />
 	</head>
 	<body>
-		{{ ansible_eth0.ipv4.address }}
+		{{ ansible_default_ipv4.address }}
 		<p id="dt"></p>
 	</body>
 	<script>


### PR DESCRIPTION
With the upgrade to Tower 3.7.0, there were a few surprises...

1. the 3.7.0 release notes indicate that the AWS EC2 inventory plugin has changed.  That changed caused the filter/tags in the AWS inventory _source_ to change which, in turn, caused the Lab2 roles to fail.
2. the schema of the returned ansible_facts appears to have changed as well.  In particular, the element(s) to retrieve the private IP address which is needed by the templates found in the lb and web tier roles in Lab2.

Also changed the wait on ec2_instance in an attempt to speed it up.